### PR TITLE
alloc: use pre-allocated error

### DIFF
--- a/tinydraw.go
+++ b/tinydraw.go
@@ -8,6 +8,8 @@ import (
 	"tinygo.org/x/drivers"
 )
 
+var errEmptyRectangle = errors.New("tinydraw: empty rectangle")
+
 // Line draws a line between two points
 func Line(display drivers.Displayer, x0 int16, y0 int16, x1 int16, y1 int16, color color.RGBA) {
 	if x0 == x1 {
@@ -66,7 +68,7 @@ func Line(display drivers.Displayer, x0 int16, y0 int16, x1 int16, y1 int16, col
 // Rectangle draws a rectangle given a point, width and height
 func Rectangle(display drivers.Displayer, x int16, y int16, w int16, h int16, color color.RGBA) error {
 	if w <= 0 || h <= 0 {
-		return errors.New("empty rectangle")
+		return errEmptyRectangle
 	}
 	Line(display, x, y, x+w-1, y, color)
 	Line(display, x, y, x, y+h-1, color)
@@ -78,7 +80,7 @@ func Rectangle(display drivers.Displayer, x int16, y int16, w int16, h int16, co
 // FilledRectangle draws a filled rectangle given a point, width and height
 func FilledRectangle(display drivers.Displayer, x int16, y int16, w int16, h int16, color color.RGBA) error {
 	if w <= 0 || h <= 0 {
-		return errors.New("empty rectangle")
+		return errEmptyRectangle
 	}
 	for i := x; i < x+w; i++ {
 		Line(display, i, y, i, y+h-1, color)


### PR DESCRIPTION
On each empty rectangle draw attempt, a new error object is created.
Instead, we can use pre-allocated one.

Context: It is very easy to try and draw an empty rectangle when drawing multiple rectangles that vary in length and/or height depending on state in app.

Related question: is it actually an error to request a zero-length or zero-height rectangle? Negative values shall probably emit and error, but why zeros emit?